### PR TITLE
Allow installing package from git

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+local = true

--- a/package.json
+++ b/package.json
@@ -6,12 +6,19 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "contracts",
+    "resources",
+    "scripts",
+    "truffle.js"
+  ],
   "scripts": {
     "package-npm": "node scripts/package-npm.js",
     "deploy": "scripts/truffle-migrate",
     "compile": "node_modules/.bin/truffle compile",
     "test": "rm -rf build && node_modules/.bin/truffle test",
-    "test-develop": "rm -rf build && node_modules/.bin/truffle test --network develop"
+    "test-develop": "rm -rf build && node_modules/.bin/truffle test --network develop",
+    "postinstall": "scripts/postinstall"
   },
   "repository": {
     "type": "git",
@@ -28,17 +35,17 @@
     "singularitynet-token-contracts": "2.0.0",
     "truffle": "4.1.13",
     "truffle-contract": "3.0.6",
-    "truffle-hdwallet-provider": "0.0.5"
+    "truffle-hdwallet-provider": "0.0.5",
+    "fs-extra": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
     "eth-gas-reporter": "^0.1.9",
-    "fs-extra": "^5.0.0",
     "moment": "^2.22.2",
     "webpack-cli": "^3.0.8",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util":"^5.2.0"
+    "ethereumjs-util": "^5.2.0"
   }
 }

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "$npm_config_local" == "true" ]]; then
+    exit 0
+fi
+
+npm run compile
+npm run package-npm
+cp -R ./build/npm-module/* .


### PR DESCRIPTION
This is to allow referring from dependent projects (such as snet-cli or snet-daemon) to latest github version without publishing it to the npm package registry.

To do so npm install hook is added which runs ```npm run package-npm``` command. ```.npmrc``` file is used to distinguish local ```npm install``` and one running from dependent project. When package is installed as dependency this file is not downloaded because it is not listed in ```files``` section of the ```package.json```. Thus ```package-npm.js``` which runs from dependent project installs ```abi``` to package root directory and when ```package-npm.js``` is started from cloned ```platform-contracts``` repository it copies files to ```build/npm-module```.