### PR TITLE
Add MultiPartyEscrow contract bytecode to package.

### DIFF
--- a/scripts/package-npm.js
+++ b/scripts/package-npm.js
@@ -34,7 +34,8 @@ const mapFiles = {
     }
     ,
     "build/contracts/MultiPartyEscrow.json": {
-        "abi": "abi/MultiPartyEscrow.json"
+        "abi": "abi/MultiPartyEscrow.json",
+        "bytecode": "bytecode/MultiPartyEscrow.json"
     },
     "resources/npm-README.md": "README.md",
     "LICENSE": "LICENSE"


### PR DESCRIPTION
Bytecode is required to deploy and use contracts for unit testing.