### PR TITLE
Keep bytecode in hex string to be compatible with abigen.

### DIFF
--- a/scripts/package-npm.js
+++ b/scripts/package-npm.js
@@ -1,5 +1,6 @@
 "use-strict";
 
+const fs = require("fs");
 const fse = require("fs-extra");
 const path = require("path");
 const npmModulePath = "build/npm-module";
@@ -17,11 +18,11 @@ const mapFiles = {
     "build/contracts/AgentFactory.json": {
         "abi": "abi/AgentFactory.json",
         "networks": "networks/AgentFactory.json",
-        "bytecode": "bytecode/AgentFactory.json"
+        "bytecode": "bytecode/AgentFactory.hex"
     },
     "build/contracts/Registry.json": {
         "networks": "networks/Registry.json",
-        "bytecode": "bytecode/Registry.json"
+        "bytecode": "bytecode/Registry.hex"
     },
     "build/contracts/IRegistry.json": {
         "abi": "abi/Registry.json"
@@ -35,7 +36,7 @@ const mapFiles = {
     ,
     "build/contracts/MultiPartyEscrow.json": {
         "abi": "abi/MultiPartyEscrow.json",
-        "bytecode": "bytecode/MultiPartyEscrow.json"
+        "bytecode": "bytecode/MultiPartyEscrow.hex"
     },
     "resources/npm-README.md": "README.md",
     "LICENSE": "LICENSE"
@@ -74,7 +75,13 @@ for (let sourceFile in mapFiles) {
             let destFile = path.join(npmModulePath, mapFiles[sourceFile][key]);
             let destParent = path.resolve(destFile, "../");
             fse.mkdirsSync(destParent);
-            fse.writeJsonSync(destFile, fse.readJsonSync(sourceFile)[key]);
+            if (key === "bytecode") {
+                // write bytecode as pure hex number string to be compatible
+                // with abigen
+                fs.writeFileSync(destFile, fse.readJsonSync(sourceFile)[key]);
+            } else {
+                fse.writeJsonSync(destFile, fse.readJsonSync(sourceFile)[key]);
+            }
         }
     } else {
         let destFile = path.join(npmModulePath, mapFiles[sourceFile]);


### PR DESCRIPTION
I found that I cannot add ```-bin ../resources/blockchain/node_modules/singularitynet-platform-contracts/bytecode/MultiPartyEscrow.json``` into [go generate header](https://github.com/singnet/snet-daemon/blob/538c8564be50b7ce2bdc9f168a4138d112658be8/blockchain/blockchain.go#L1) as it contains bytecode as hex string in JSON format, i.e. ```"0x3..."``` with quotes. ```abigen``` just copies the string with the code into go code and deploying contract doesn't work properly.

This PR proposes publishing *.hex files instead which doesn't have quotes and can be used by abigen directly. I have removed old *.json bytecode file because I didn't find its usages but please shout if I missed something - it can be added as well. 

Another option is to remove quotes before calling abigen but it can make ```go generate``` header less obvious. Actually I don't know whether there is some standard tool which can load bytecode in JSON format without removing quotes.

Similar PR for token-contracts https://github.com/singnet/token-contracts/pull/8
