### PR TITLE
Revert "Allow installing package from git"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-local = true

--- a/package.json
+++ b/package.json
@@ -6,19 +6,12 @@
   "directories": {
     "test": "test"
   },
-  "files": [
-    "contracts",
-    "resources",
-    "scripts",
-    "truffle.js"
-  ],
   "scripts": {
     "package-npm": "node scripts/package-npm.js",
     "deploy": "scripts/truffle-migrate",
     "compile": "node_modules/.bin/truffle compile",
     "test": "rm -rf build && node_modules/.bin/truffle test",
-    "test-develop": "rm -rf build && node_modules/.bin/truffle test --network develop",
-    "postinstall": "scripts/postinstall"
+    "test-develop": "rm -rf build && node_modules/.bin/truffle test --network develop"
   },
   "repository": {
     "type": "git",
@@ -35,17 +28,17 @@
     "singularitynet-token-contracts": "2.0.0",
     "truffle": "4.1.13",
     "truffle-contract": "3.0.6",
-    "truffle-hdwallet-provider": "0.0.5",
-    "fs-extra": "^5.0.0"
+    "truffle-hdwallet-provider": "0.0.5"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
     "eth-gas-reporter": "^0.1.9",
+    "fs-extra": "^5.0.0",
     "moment": "^2.22.2",
     "webpack-cli": "^3.0.8",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "^5.2.0"
+    "ethereumjs-util":"^5.2.0"
   }
 }

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ "$npm_config_local" == "true" ]]; then
-    exit 0
-fi
-
-npm run compile
-npm run package-npm
-cp -R ./build/npm-module/* .


### PR DESCRIPTION
Reverts singnet/platform-contracts#51. I am reverting the change because it seems that publishing releases on GitHub is simpler and less error prone. See issue https://github.com/singnet/platform-contracts/issues/53.