### PR TITLE
add metadataIPFSHash to ServiceRegistration in Registry contract

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -28,6 +28,7 @@ contract Registry is IRegistry, ERC165 {
         bytes32 serviceName;
         bytes32 servicePath;
         address agentAddress;
+        bytes   metadataIPFSHash;  // IPFSHash of service metadata (in the case of MPE payment system)
 
         bytes32[] tags;
         mapping(bytes32 => Tag) tagsByName;
@@ -313,6 +314,15 @@ contract Registry is IRegistry, ERC165 {
             servicesByTag[tagName].orgNames.push(orgName);
             servicesByTag[tagName].itemNames.push(serviceName);
         }
+    }
+
+    function setMetadataIPFSHashInServiceRegistration(bytes32 orgName, bytes32 serviceName, bytes metadataIPFSHash)
+    public
+    {
+        requireOrgExistenceConstraint(orgName, true);
+        requireAuthorization(orgName, true);
+        requireServiceExistenceConstraint(orgName, serviceName, true);
+        orgsByName[orgName].servicesByName[serviceName].metadataIPFSHash = metadataIPFSHash;
     }
 
     function removeTagsFromServiceRegistration(bytes32 orgName, bytes32 serviceName, bytes32[] tags) external {
@@ -627,6 +637,25 @@ contract Registry is IRegistry, ERC165 {
         path = orgsByName[orgName].servicesByName[serviceName].servicePath;
         agentAddress = orgsByName[orgName].servicesByName[serviceName].agentAddress;
         tags = orgsByName[orgName].servicesByName[serviceName].tags;
+    }
+
+    function getMetadataIPFSHash(bytes32 orgName, bytes32 serviceName) external view
+            returns (bool found, bytes metadataIPFSHash) {
+
+        // check to see if this organization exists
+        if(orgsByName[orgName].organizationName == bytes32(0x0)) {
+            found = false;
+            return;
+        }
+
+        // check to see if this repo exists
+        if(orgsByName[orgName].servicesByName[serviceName].serviceName == bytes32(0x0)) {
+            found = false;
+            return;
+        }
+
+        found = true;
+        metadataIPFSHash = orgsByName[orgName].servicesByName[serviceName].metadataIPFSHash;
     }
 
     function listTypeRepositoriesForOrganization(bytes32 orgName) external view returns (bool found, bytes32[] repositoryNames) {

--- a/test/Registry_metadata_test1.js
+++ b/test/Registry_metadata_test1.js
@@ -1,0 +1,26 @@
+"use strict";
+var Registry = artifacts.require("./Registry.sol");
+
+contract('Registry', function(accounts) {
+
+    var registry;
+     
+
+    before(async () => 
+        {
+            registry      = await Registry.deployed();
+        });
+
+
+    it ("set/get metadata", async function()
+        { 
+            let orgName     = "TestName" 
+            let serviceName = "ServiceName"
+            let metadata    = "LONG \"BINARY\" STRING 42424242424242424242424242424242424242424242424242424242424"
+            await registry.createOrganization(orgName, [accounts[1]]);
+            await registry.createServiceRegistration(orgName, serviceName, "", accounts[5], [])
+            await registry.setMetadataIPFSHashInServiceRegistration(orgName, serviceName,  metadata)
+            let rez = await registry.getMetadataIPFSHash(orgName, serviceName)
+            assert.equal(web3.toAscii(rez[1]), metadata)
+        });
+});


### PR DESCRIPTION
We need it for register service with MPE payment system

I made separate functions setMetadataIPFSHashInServiceRegistration and getMetadataIPFSHash in order to not influence old logic at all.

When Agent/Jobs will be removed, we will need to add metadataIPFSHash in createServiceRegistration and getServiceRegistrationByName (if I do it now, I will break Agent/Job related logic in snet-cli)
