### PR TITLE
Modification of #59 for making next Development release

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -316,9 +316,7 @@ contract Registry is IRegistry, ERC165 {
         }
     }
 
-    function setMetadataIPFSHashInServiceRegistration(bytes32 orgName, bytes32 serviceName, bytes metadataIPFSHash)
-    public
-    {
+    function setMetadataIPFSHashInServiceRegistration(bytes32 orgName, bytes32 serviceName, bytes metadataIPFSHash) external {
         requireOrgExistenceConstraint(orgName, true);
         requireAuthorization(orgName, true);
         requireServiceExistenceConstraint(orgName, serviceName, true);

--- a/scripts/package-npm.js
+++ b/scripts/package-npm.js
@@ -23,7 +23,7 @@ const mapFiles = {
         "networks": "networks/Registry.json",
         "bytecode": "bytecode/Registry.json"
     },
-    "build/contracts/IRegistry.json": {
+    "build/contracts/Registry.json": {
         "abi": "abi/Registry.json"
     },
     "build/contracts/Agent.json": {


### PR DESCRIPTION
1. (minor) make setMetadataIPFSHashInServiceRegistration external instead of public, for code unification (and it should be cheaper)
2. use Registry ABI instead of IRegistry ABI in package-npm.js .  I didn't add new methods directly to IRegistry in order to not break old logic for now. 
