### PR TITLE
add nonce to events

### DIFF
--- a/contracts/MultiPartyEscrow.sol
+++ b/contracts/MultiPartyEscrow.sol
@@ -86,21 +86,21 @@ contract MultiPartyEscrow {
     //open a channel, token should be already being deposit
     //openChannel should be run only once for given sender, recipient, groupId
     //channel can be reused even after channelClaim(..., isSendback=true)
-    function openChannel(address  recipient, uint256 value, uint256 expiration, bytes32 groupId, address signer) 
+    function openChannel(address signer, address recipient, bytes32 groupId, uint256 value, uint256 expiration)
     public
-    returns(bool) 
+    returns(bool)
     {
         require(balances[msg.sender] >= value);
         require(signer != address(0));
 
         channels[nextChannelId] = PaymentChannel({
-            sender       : msg.sender,
-            recipient    : recipient,
-            value        : value,
-            groupId      : groupId,
             nonce        : 0,
-            expiration   : expiration,
-            signer       : signer
+            sender       : msg.sender,
+            signer       : signer,
+            recipient    : recipient,
+            groupId      : groupId,
+            value        : value,
+            expiration   : expiration
         });
       
         balances[msg.sender] = balances[msg.sender].sub(value);  
@@ -111,12 +111,12 @@ contract MultiPartyEscrow {
     
 
 
-    function depositAndOpenChannel(address  recipient, uint256 value, uint256 expiration, bytes32 groupId, address signer)
+    function depositAndOpenChannel(address signer, address recipient, bytes32 groupId, uint256 value, uint256 expiration)
     public
     returns(bool)
     {
         require(deposit(value));
-        require(openChannel(recipient, value, expiration, groupId, signer));
+        require(openChannel(signer, recipient, groupId, value, expiration));
         return true;
     }
 

--- a/contracts/MultiPartyEscrow.sol
+++ b/contracts/MultiPartyEscrow.sol
@@ -39,6 +39,8 @@ contract MultiPartyEscrow {
     event ChannelSenderClaim(uint256 indexed channelId, uint256 nonce, uint256 claimAmount);
     event ChannelExtend(uint256 indexed channelId, uint256 newExpiration);
     event ChannelAddFunds(uint256 indexed channelId, uint256 additionalFunds);
+    event DepositFunds(address indexed sender, uint256 amount);
+    event WithdrawFunds(address indexed sender, uint256 amount);
     event TransferFunds(address indexed sender, address indexed receiver, uint256 amount);
 
     constructor (address _token)
@@ -53,6 +55,7 @@ contract MultiPartyEscrow {
     {
         require(token.transferFrom(msg.sender, this, value), "Unable to transfer token to the contract"); 
         balances[msg.sender] = balances[msg.sender].add(value);
+        emit DepositFunds(msg.sender, value);
         return true;
     }
     
@@ -63,6 +66,7 @@ contract MultiPartyEscrow {
         require(balances[msg.sender] >= value);
         require(token.transfer(msg.sender, value));
         balances[msg.sender] = balances[msg.sender].sub(value);
+        emit WithdrawFunds(msg.sender, value);
         return true;
     }
     

--- a/test/MultiPartyEscrow_test1.js
+++ b/test/MultiPartyEscrow_test1.js
@@ -88,17 +88,17 @@ contract('MultiPartyEscrow', function(accounts) {
 
             //first try to open with bigger amount (it must fail)
             // sending signer as sender itself
-            testErrorRevert( escrow.openChannel(accounts[5], N1 + 1, web3.eth.blockNumber + 10000000, 0, accounts[0], {from:accounts[0]}))
+            testErrorRevert( escrow.openChannel(accounts[0], accounts[5], 0, N1 + 1, web3.eth.blockNumber + 10000000, {from:accounts[0]}))
             
             //normal open
-            await escrow.openChannel(accounts[5], N1, web3.eth.blockNumber + 10000000, 0, accounts[0], {from:accounts[0]})
+            await escrow.openChannel(accounts[0], accounts[5], 0, N1, web3.eth.blockNumber + 10000000, {from:accounts[0]})
             assert.equal((await escrow.nextChannelId.call()).toNumber(), 1)
 
             //full balance doesn't change
             assert.equal((await token.balanceOf(escrow.address)).toNumber(), N1 + N2 - N3)
             assert.equal((await escrow.balances.call(accounts[0])).toNumber(), 0)
             //second channel
-            await escrow.openChannel(accounts[6], N1 * 2, web3.eth.blockNumber + 10000000, 27, accounts[4], {from:accounts[4]})
+            await escrow.openChannel(accounts[4], accounts[6], 27, N1 * 2, web3.eth.blockNumber + 10000000, {from:accounts[4]})
             assert.equal((await escrow.nextChannelId.call()).toNumber(), 2)
             
             assert.equal((await escrow.balances.call(accounts[4])).toNumber(), N2 - N3 - N1 * 2)
@@ -161,7 +161,7 @@ contract('MultiPartyEscrow', function(accounts) {
             let expiration   = web3.eth.blockNumber + 10000000
             let value        = 1000
             let groupId      = "group44"
-            await escrow.openChannel(accounts[7], value, expiration, groupId, accounts[4], {from:accounts[4]})
+            await escrow.openChannel(accounts[4], accounts[7], groupId, value, expiration, {from:accounts[4]})
             assert.equal((await escrow.nextChannelId.call()).toNumber(), 3)     
             assert.equal((await escrow.balances.call(accounts[4])).toNumber(), N2 - N3 - N1*2)
         });
@@ -201,7 +201,7 @@ contract('MultiPartyEscrow', function(accounts) {
         {
             let expiration   = web3.eth.blockNumber - 1
             let groupId      = "group42"
-            await escrow.openChannel(accounts[7], 10, expiration, groupId, accounts[4], {from:accounts[4]})
+            await escrow.openChannel(accounts[4], accounts[7], groupId, 10, expiration, {from:accounts[4]})
             assert.equal((await escrow.nextChannelId.call()).toNumber(), 4)     
             assert.equal((await escrow.balances.call(accounts[4])).toNumber(), N2 - N3 - N1*2)
             


### PR DESCRIPTION
This pull request add nonce to events.

1. I'm not sure that we need nonce in ChannelOpen event because it is always 0... 
2. Probably we should rearrange order of variables inside struct PaymentChannel (and maybe inside events also) to make it more logical..