### PR TITLE
Enhancements to Claim functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,14 @@ Includes SingularityNET platform contracts, migrations, tests
 npm install
 ```
 
+### Compile 
+```bash
+truffle compile
+```
+
 ### Test 
 ```bash
-npm run test
+truffle test
 ```
 
 ## Package

--- a/contracts/MultiPartyEscrow.sol
+++ b/contracts/MultiPartyEscrow.sol
@@ -199,7 +199,7 @@ contract MultiPartyEscrow {
         bytes32 message = prefixed(keccak256(abi.encodePacked("__MPE_claim_message", this, channelId, channel.nonce, plannedAmount)));
         // check that the signature is from the signer
         address signAddress = ecrecover(message, v, r, s);
-        require(signAddress == channel.signer, "Invalid signature");
+        require(signAddress == channel.signer || signAddress == channel.sender, "Invalid signature");
         
         //transfer amount from the channel to the sender
         channel.value        =        channel.value.sub(actualAmount);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "singularitynet-platform-contracts",
-  "version": "0.3.1-beta",
+  "version": "0.3.2-beta",
   "private": true,
   "description": "Includes SingularityNET platform contracts, migrations, tests",
   "directories": {


### PR DESCRIPTION
Enhance the claim functionality where the signatures can be either from the Sender or Signer. 

This is required for certain scenarios like the channel created with the a Signer (different than Sender) who signs the service call transactions. This limits the user not to reuse the channel if he wants to sign the transactions especially if he/she want to manage the channel by themselves not by the Signer anymore.
This will be one of the use case in DApp where users can leverage the signer service until they get familiarized with Blockchain and later they should be able to manage by themselves for say with Metamask.